### PR TITLE
Set ‘reQueueAfter’ to true

### DIFF
--- a/Tdarr_Plugin_lmg1_Reorder_Streams.js
+++ b/Tdarr_Plugin_lmg1_Reorder_Streams.js
@@ -45,7 +45,7 @@ function plugin(file) {
 
       response.infoLog += "Video is not in the first stream"
       response.preset = ',-map 0:v? -map 0:a? -map 0:s? -map 0:d? -map 0:t? -c copy'
-      response.reQueueAfter = false;
+      response.reQueueAfter = true;
       response.processFile = true;
 
       return response


### PR DESCRIPTION
I’ve updated the community plugin already. All plugins should requeue the file afterwards in case a plugin stack is being used. I’ll  update the plugin tutorial/documentation on Monday to reflect this.